### PR TITLE
Improve responsive styles and add map links

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                     <div class="event-card__info">
                         <p class="event-card__time">10:40</p>
                         <p class="event-card__title">Роспись</p>
-                        <a href="#" class="event-card__link">
+                        <a href="https://yandex.ru/maps/-/CLQWe42B" class="event-card__link" target="_blank">
                             <img src="./assets/icons/location.svg" alt="Location">
                             <span>Краснодар, ул. Гагарина, 212</span>
                             <img src="./assets/icons/arrow-right.svg" alt="Arrow">
@@ -75,7 +75,7 @@
                     <div class="event-card__info">
                         <p class="event-card__time">12:00—10:00</p>
                         <p class="event-card__title">Вечеринка</p>
-                        <a href="#" class="event-card__link">
+                        <a href="https://yandex.ru/maps/-/CLQWeO4a" class="event-card__link" target="_blank">
                             <img src="./assets/icons/location.svg" alt="Location">
                             <span>Краснодар, ул. Средняя, 47/3</span>
                             <img src="./assets/icons/arrow-right.svg" alt="Arrow">

--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@ body {
     align-items: center;
 }
 
+html {
+    font-size: clamp(10px, 2vw, 16px);
+}
+
 a {
     text-decoration: none;
     color: inherit;
@@ -180,13 +184,13 @@ DESKTOP STYLES (экраны > 900px)
 BLOCK CONTENT STYLES
 ==============================================
 */
-.item-1 { display: flex; flex-direction: column; justify-content: center; padding: 30px; font-size: 30px; font-weight: var(--font-weight-medium); }
+.item-1 { display: flex; flex-direction: column; justify-content: center; padding: 30px; font-size: 1.875rem; font-weight: var(--font-weight-medium); }
 .item-2 { background-size: cover; background-position: center; }
 .item-3 { padding: 30px; }
 .dress-code { display: flex; justify-content: space-between; align-items: center; width: 100%; height: 100%; }
 .dress-code__text { display: flex; flex-direction: column; }
-.dress-code__title { font-size: 30px; font-weight: var(--font-weight-medium); }
-.dress-code__subtitle { font-size: 20px; font-weight: var(--font-weight-regular); }
+.dress-code__title { font-size: 1.875rem; font-weight: var(--font-weight-medium); }
+.dress-code__subtitle { font-size: 1.25rem; font-weight: var(--font-weight-regular); }
 .dress-code__icons { display: flex; gap: 15px; }
 .dress-code__icons img { width: auto; height: 60px; }
 .item-4, .item-5 { background-size: cover; background-position: center; display: flex; align-items: flex-end; }
@@ -203,21 +207,20 @@ BLOCK CONTENT STYLES
     transform: translateZ(0); /* Вот это исправление */
 }
 
-.event-card__time { font-size: 40px; font-weight: var(--font-weight-medium); }
-.event-card__title { font-size: 30px; font-weight: var(--font-weight-regular); margin-bottom: 20px; }
+.event-card__time { font-size: 2.5rem; font-weight: var(--font-weight-medium); }
+.event-card__title { font-size: 1.875rem; font-weight: var(--font-weight-regular); margin-bottom: 20px; }
 .event-card__link {
-        
     padding: 30px;
-    border-radius: 20px; 
-    display: flex; align-items: center; gap: 10px; font-size: 18px; font-weight: var(--font-weight-regular); }
+    border-radius: 20px;
+    display: flex; align-items: center; gap: 10px; font-size: 1.125rem; font-weight: var(--font-weight-regular); transition: background-color 0.3s, color 0.3s; }
 
 .event-card__link img:first-child { width: 15px; }
 .event-card__link img:last-child { width: 15px; margin-left: auto; }
 .item-6 { padding: 30px; }
-.important-link { display: flex; justify-content: space-between; align-items: center; width: 100%; height: 100%; }
+.important-link { display: flex; justify-content: space-between; align-items: center; width: 100%; height: 100%; transition: background-color 0.3s, color 0.3s; }
 .important-link__text { display: flex; flex-direction: column; }
-.important-link__title { font-size: 40px; font-weight: var(--font-weight-medium); margin-bottom: 10px; }
-.important-link__subtitle { font-size: 18px; font-weight: var(--font-weight-medium); max-width: 80%; }
+.important-link__title { font-size: 2.5rem; font-weight: var(--font-weight-medium); margin-bottom: 10px; }
+.important-link__subtitle { font-size: 1.125rem; font-weight: var(--font-weight-medium); max-width: 80%; }
 .important-link__icon img { width: 25px; }
 
 /* 
@@ -226,7 +229,7 @@ MOBILE STYLES (экраны <= 900px)
 ==============================================
 */
 @media (max-width: 900px) {
-    body { overflow-x: hidden; }
+    html, body { overflow-x: hidden; }
     
     .page-wrapper {
         width: 100%;
@@ -248,7 +251,7 @@ MOBILE STYLES (экраны <= 900px)
     .horizontal-scroll-wrapper::-webkit-scrollbar { display: none; }
     .horizontal-scroll-wrapper .grid-item { flex: 0 0 80%; scroll-snap-align: start; }
     .grid-item { border-radius: var(--border-radius-mobile); }
-    .item-1 { font-size: 24px; padding: 20px; }
+    .item-1 { font-size: 1.5rem; padding: 20px; }
     
     .event-card__info { 
         border-radius: var(--border-radius-mobile); 
@@ -257,9 +260,15 @@ MOBILE STYLES (экраны <= 900px)
     .item-3, .item-6, .event-card__info { padding: 20px; }
     .dress-code { flex-direction: column; align-items: flex-start; gap: 20px; }
     .dress-code__icons img { height: 40px; }
-    .event-card__time { font-size: 32px; }
-    .event-card__title { font-size: 24px; }
-    .event-card__link { font-size: 16px; }
-    .important-link__title { font-size: 32px; }
-    .important-link__subtitle { font-size: 16px; max-width: 100%; }
+    .event-card__time { font-size: 2rem; }
+    .event-card__title { font-size: 1.5rem; }
+    .event-card__link { font-size: 1rem; }
+    .important-link__title { font-size: 2rem; }
+    .important-link__subtitle { font-size: 1rem; max-width: 100%; }
+}
+
+.event-card__link:hover,
+.important-link:hover {
+    background-color: #0E25D7;
+    color: #FFFFFF;
 }


### PR DESCRIPTION
## Summary
- make typography responsive with `rem` units and clamp-based root font size
- add hover styling for event and important links
- populate event cards with Yandex map links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc27809d54832c90fa5c526d3a422d